### PR TITLE
ci: fix duplicated worktree commit

### DIFF
--- a/.github/workflows/trigger-workflow.yml
+++ b/.github/workflows/trigger-workflow.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 0 * * *'
 
   workflow_dispatch:
 
@@ -46,10 +46,15 @@ jobs:
           
           # Add changes if any exist
           if [ -n "$(git status --porcelain)" ]; then
+            # Create a new branch for worktree updates
+            BRANCH_NAME="worktree"
+            git checkout -b "$BRANCH_NAME"
+            
             git add .hoa/worktree.json
             git commit -m "Update worktree [skip ci]"
-            git push origin main
-            echo "Worktree updated and committed to main branch"
+            git push origin "$BRANCH_NAME"
+            echo "Worktree updated and committed to branch $BRANCH_NAME"
+            
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
在新的分支中保存工作树信息，而不是在原先的主分支保存